### PR TITLE
Reuse userId in all queries

### DIFF
--- a/feedback.py
+++ b/feedback.py
@@ -18,14 +18,14 @@ def thanksReceived(username):
 		data = cur.fetchall()
 	return data[0][0]
 
-def featuredImages(username):
+def featuredImages(userId):
 	awards = ['Featured_pictures_on_Wikimedia_Commons', 'Quality_images']
 	sqlins = []
 	for award in awards:
 		sqlins.append('"' + award + '"')
 	sqlin = ", ".join(sqlins)
 	with conn.cursor() as cur:
-		sql = 'select count(cl_from), cl_to from categorylinks where cl_to in (%s) and cl_type="file" and cl_from in (select log_page from logging_userindex where log_type="upload" and log_user=(select user_id from user where user_name="%s")) group by cl_to;' % (sqlin, username)
+		sql = 'select count(cl_from), cl_to from categorylinks where cl_to in (%s) and cl_type="file" and cl_from in (select log_page from logging_userindex where log_type="upload" and log_user=%d) group by cl_to;' % (sqlin, userId)
 		cur.execute(sql)
 		data = cur.fetchall()
 	response = {}
@@ -36,23 +36,23 @@ def featuredImages(username):
 			response[award] = 0
 	return response
 
-def articlesUsingImages(username):
+def articlesUsingImages(userId):
 	with conn.cursor() as cur:
-		sql = 'select count(*) from globalimagelinks where gil_to in (select log_title from logging_userindex where log_type="upload" and log_user=(select user_id from user where user_name="%s"));' % username
+		sql = 'select count(*) from globalimagelinks where gil_to in (select log_title from logging_userindex where log_type="upload" and log_user=%d);' % userId
 		cur.execute(sql)
 		data = cur.fetchall()
 	return data[0][0]
 
-def uniqueUsedImages(username):
+def uniqueUsedImages(userId):
 	with conn.cursor() as cur:
-		sql = 'select count(distinct gil_to) from globalimagelinks where gil_to in (select log_title from logging_userindex where log_type="upload" and log_user=(select user_id from user where user_name="%s"));' % username
+		sql = 'select count(distinct gil_to) from globalimagelinks where gil_to in (select log_title from logging_userindex where log_type="upload" and log_user=%d);' % userId
 		cur.execute(sql)
 		data = cur.fetchall()
 	return data[0][0]
 
-def imagesEditedBySomeoneElse(username):
+def imagesEditedBySomeoneElse(userId):
 	with conn.cursor() as cur:
-		sql = 'select count(*) from revision where rev_page in (select log_page from logging_userindex where log_type="upload" and log_user=(select user_id from user where user_name="%s")) and rev_user!=(select user_id from user where user_name="%s") group by rev_page having count(*)>1' % (username, username)
+		sql = 'select count(*) from revision where rev_page in (select log_page from logging_userindex where log_type="upload" and log_user=%d) and rev_user!=%d group by rev_page having count(*)>1' % (userId, userId)
 		cur.execute(sql)
 		data = cur.fetchall()
 	return len(data)
@@ -60,6 +60,13 @@ def imagesEditedBySomeoneElse(username):
 def deletedUploads(username):
 	with conn.cursor() as cur:
 		sql = 'select count(*) from filearchive where fa_user_text="' + username + '";'
+		cur.execute(sql)
+		data = cur.fetchall()
+	return data[0][0]
+
+def getUserId(username):
+    	with conn.cursor() as cur:
+		sql = 'select user_id from user where user_name="%s";' % username
 		cur.execute(sql)
 		data = cur.fetchall()
 	return data[0][0]
@@ -103,16 +110,19 @@ response = {
 	'status': 'ok',
 	'user': user,
 }
+
+userid = getUserId(user)
+
 if 'thanksReceived' in fetch:
 	response['thanksReceived'] = thanksReceived(user)
 if 'featuredImages' in fetch:
-	response['featuredImages'] = featuredImages(user)
+	response['featuredImages'] = featuredImages(userid)
 if 'articlesUsingImages' in fetch:
-	response['articlesUsingImages'] = articlesUsingImages(user)
+	response['articlesUsingImages'] = articlesUsingImages(userid)
 if 'uniqueUsedImages' in fetch:
-	response['uniqueUsedImages'] = uniqueUsedImages(user)
+	response['uniqueUsedImages'] = uniqueUsedImages(userid)
 if 'imagesEditedBySomeoneElse' in fetch:
-	response['imagesEditedBySomeoneElse'] = imagesEditedBySomeoneElse(user)
+	response['imagesEditedBySomeoneElse'] = imagesEditedBySomeoneElse(userid)
 if 'deletedUploads' in fetch:
 	response['deletedUploads'] = deletedUploads(user)
 


### PR DESCRIPTION
Fixes #8. 

`userId` was being fetched a total of 5 times if `feedback.py` was called without any parameters ie. if all the statistics were queried.

I have extracted out the fetching of `userId` to a separate function and have started passing `userId` to the various functions instead of them querying the `userId` individually. 

This should save us some time while trying to query all the statistics for a particular user. 