### PR TITLE
API to get count of Wikidata edits

### DIFF
--- a/wikidataedits.py
+++ b/wikidataedits.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
+#-*- coding: utf-8 -*-
 
 import os
 import cgi
+import json
 import sys
 from wmflabs import db
 
@@ -31,4 +33,5 @@ with cur:
 	data = cur.fetchall()
 
 result = data[0][0]
-print {"edits": result}
+response = {"edits": result}
+print jsonify(response)

--- a/wikidataedits.py
+++ b/wikidataedits.py
@@ -7,6 +7,9 @@ import json
 import sys
 from wmflabs import db
 
+def jsonify(response):
+	return json.dumps(response)
+
 #Print header
 print 'Content-type: application/json'
 
@@ -33,5 +36,10 @@ with cur:
 	data = cur.fetchall()
 
 result = data[0][0]
-response = {"edits": result}
+
+response = {
+    'edits': result
+}
+
+print
 print jsonify(response)

--- a/wikidataedits.py
+++ b/wikidataedits.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import os
+import cgi
+import sys
+from wmflabs import db
+
+#Print header
+print 'Content-type: application/json'
+
+# Fetch params
+if 'QUERY_STRING' in os.environ:
+	QS = os.environ['QUERY_STRING']
+	qs = cgi.parse_qs(QS)
+	try:
+		username = qs['user'][0].replace('_', ' ')
+	except:
+		print 'nouser'
+		sys.exit(0)
+else:
+	print 'nouser'
+	sys.exit(0)
+
+##### PROGRAM ####
+
+conn = db.connect('wikidatawiki')
+cur = conn.cursor()
+with cur:
+	sql = 'select count(*) as edit_count from change_tag join revision on rev_id=ct_rev_id where ct_tag="wikimedia-commons-app" and rev_user_text="' + username + '";'
+	cur.execute(sql)
+	data = cur.fetchall()
+
+result = data[0][0]
+print {"edits": result}


### PR DESCRIPTION
As suggested by @urbanecm I have hosted it using my tools account for testing purpose. The API returns the number of edits made by a user. 

https://tools.wmflabs.org/commons-android-app/tool-commons-android-app/wikidataedits.py?user=Maskaravivek